### PR TITLE
Fix manual installation

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -1,0 +1,1 @@
+sam/platform.txt


### PR DESCRIPTION
See CONTRIBUTING.md for installation instructions.  I found the IDE complained about platform.txt missing at the top-level.  Replicating the file via symlink seemed to fix it.