### PR TITLE
Change LED_BUILTIN to be on the end of the board

### DIFF
--- a/sam/variants/m2/variant.h
+++ b/sam/variants/m2/variant.h
@@ -128,7 +128,7 @@ extern "C"{
 #define RGB_BLUE   DS7_BLUE     // RGB Blue LED
 
 
-#define LED_BUILTIN     DS2
+#define LED_BUILTIN     RGB_BLUE
 /*
 #define PIN_LED_13      DS2
 #define PIN_LED_RXL     DS7_GREEN


### PR DESCRIPTION
Change LED_BUILTIN to be on the end of the board. This should make it easier to see when plugged into the OBD2 connection.

Fixes #13. 