### PR TITLE
ADC disable update

### DIFF
--- a/sam/variants/m2/variant.cpp
+++ b/sam/variants/m2/variant.cpp
@@ -482,6 +482,7 @@ void init( void )
   pmc_enable_periph_clk(ID_ADC);
   adc_init(ADC, SystemCoreClock, ADC_FREQ_MAX, ADC_STARTUP_FAST);
 
+  adc_disable_all_channel(ADC);
   adc_enable_channel(ADC, ADC_CHANNEL_12); // Analog1
   adc_enable_channel(ADC, ADC_CHANNEL_11); // Analog2
   adc_enable_channel(ADC, ADC_CHANNEL_0);  // Analog3
@@ -497,7 +498,6 @@ void init( void )
   adc_configure_timing(ADC, 0, ADC_SETTLING_TIME_3, 1);
   adc_configure_trigger(ADC, ADC_TRIG_SW, 0); // Disable hardware trigger.
   adc_disable_interrupt(ADC, 0xFFFFFFFF); // Disable all ADC interrupts.
-  adc_disable_all_channel(ADC);
 
 
   // Initialize analogOutput module


### PR DESCRIPTION
Changed position of adc_disable_all_channel(ADC); because we were
enabling ADC channels then we Disabled all channels. by moving to the
beginning of the ADC configuration we now disable all channels then
enable the channels we need