### PR TITLE
Correct GPIO expression on the M2 Beta

### DIFF
--- a/sam/platform.txt
+++ b/sam/platform.txt
@@ -64,13 +64,13 @@ build.usb_manufacturer="Unknown"
 # ---------------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mcpu={build.mcu} -mthumb -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.libsam.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mcpu={build.mcu} -mthumb -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DMACCHINA_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.libsam.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mcpu={build.mcu} -mthumb -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {compiler.libsam.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mcpu={build.mcu} -mthumb -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DMACCHINA_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {compiler.libsam.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -mcpu={build.mcu} -mthumb -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {compiler.libsam.c.flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -mcpu={build.mcu} -mthumb -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DMACCHINA_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {compiler.libsam.c.flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 # archive_file_path is needed for backwards compatibility with IDE 1.6.5 or older, IDE 1.6.6 or newer overrides this value

--- a/sam/variants/m2/variant.h
+++ b/sam/variants/m2/variant.h
@@ -33,16 +33,6 @@
  *        Definitions
  *----------------------------------------------------------------------------*/
 
-/*************************************************************************************
-*                   WARNING for use with M2 BETA  Hardware ONLY                      *
-* Uncomment the following define to use the BETA version of the GPIOx_B sink OUTPUTS *
-*                                                                                    *
-*************************************************************************************/
-
-//#define M2_Beta
-
-/************************************************************************************/
-
 /** Frequency of the board main oscillator */
 #define VARIANT_MAINOSC     12000000
 
@@ -146,7 +136,7 @@ extern "C"{
 #define GPIO5           28
 #define GPIO6           29
 
-#ifdef M2_Beta  // M2 Beta legacy Hardware Sink Input Pins
+#ifdef MACCHINA_M2_BETA  // M2 Beta legacy Hardware Sink Input Pins
     // M2 GPIO_B pins for Sinking INPUT Pins
     #define GPIO1_B     30
     #define GPIO2_B     31


### PR DESCRIPTION
Correct GPIO expression on the M2 Beta.  Done by standardizing on the MACCHINA_M2_BETA constant.

Previously one area was expecting `M2_Beta` to be defined while the definition was defining `ARDUINO_M2_BETA`.