### PR TITLE
Include due_can as a library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sam/libraries/due_can"]
+	path = sam/libraries/due_can
+	url = https://github.com/collin80/due_can.git


### PR DESCRIPTION
This library is being included because it is consistently the reccomended choice for CAN on the M2.