### PR TITLE
Configure analog connections to use maximum resolution

### DIFF
--- a/sam/variants/m2/variant.cpp
+++ b/sam/variants/m2/variant.cpp
@@ -506,6 +506,10 @@ void init( void )
 
   // Initialize analogOutput module
   analogOutputInit();
+
+  analogWriteResolution(12u);		// set analogue write resolution to 12bit resolution
+  analogReadResolution(12u);		// set analogue read resolution to 12 bits resolution
+
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is a reintroduction of #18 now that #26 decided we are not maintaining Due compatibility.